### PR TITLE
Refactor FormBuilder API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,11 +105,10 @@ const form = FormBuilder.create({
   email: ''
 })
 
-form.submitAt('/api/users')
+form.post('/api/users')
   .onSuccess(data => {
     console.log('Form submitted successfully:', data)
   })
-  .submit()
 ```
 
 #### Listing


### PR DESCRIPTION
## Summary
- refactor `FormBuilder` to provide Inertia-like methods
- update README example to use the new API

## Testing
- `npx vitest run` *(fails: Listing.spec.js - allow reset filter)*

------
https://chatgpt.com/codex/tasks/task_e_6840f50ce910832caf4bd1d881d80c90