### PR TITLE
Refactor FormBuilder state management

### DIFF
--- a/src/components/WyxosForm.vue
+++ b/src/components/WyxosForm.vue
@@ -59,7 +59,7 @@ export default {
     <slot></slot>
   </form>
   <o-loading v-else-if="form.isLoading" :active="true"></o-loading>
-  <o-button v-else-if="form.isFailure" @click="form.load()">
+  <o-button v-else-if="form.isLoadFailed" @click="form.load()">
     Error. Retry or refresh.
   </o-button>
 </template>

--- a/tests/utilities/FormBuilder.spec.js
+++ b/tests/utilities/FormBuilder.spec.js
@@ -8,6 +8,7 @@ vi.stubGlobal('window', {})
 describe('FormBuilder', () => {
   beforeEach(() => {
     axios.post.mockReset()
+    axios.get.mockReset()
   })
 
   it('creates instance and exposes fields', () => {
@@ -30,6 +31,8 @@ describe('FormBuilder', () => {
 
     expect(sent).toEqual({ url: '/api', data: { name: 'John' } })
     expect(form.isSubmitted).toBe(true)
+    expect(form.successful).toBe(true)
+    expect(form.wasSubmitting).toBe(true)
     expect(form.name).toBe('')
   })
 
@@ -52,5 +55,28 @@ describe('FormBuilder', () => {
     await expect(form.post('/api')).rejects.toBeDefined()
     expect(form.hasError('name')).toBe(true)
     expect(form.isSubmitFailed).toBe(true)
+    expect(form.failed).toBe(true)
+    expect(form.wasSubmitting).toBe(true)
+  })
+
+  it('loads data and updates state on success', async () => {
+    axios.get.mockResolvedValueOnce({ data: { form: { name: 'Jane' } } })
+    const form = FormBuilder.create({ name: '' })
+
+    await form.load('/api')
+
+    expect(form.loaded).toBe(true)
+    expect(form.wasLoading).toBe(true)
+    expect(form.name).toBe('Jane')
+  })
+
+  it('handles failed load', async () => {
+    axios.get.mockRejectedValueOnce({})
+    const form = FormBuilder.create({ name: '' })
+
+    await expect(form.load('/api')).rejects.toBeDefined()
+
+    expect(form.failed).toBe(true)
+    expect(form.wasLoading).toBe(true)
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,13 @@ export class FormBuilder<T extends Record<string, any> = Record<string, any>> {
   form: T;
   original: T;
 
+  readonly successful: boolean;
+  readonly failed: boolean;
+  readonly loading: boolean;
+  readonly loaded: boolean;
+  readonly wasLoading: boolean;
+  readonly wasSubmitting: boolean;
+
   readonly isSubmitting: boolean;
   readonly isSubmitted: boolean;
   readonly isSubmitFailed: boolean;
@@ -41,12 +48,12 @@ export class FormBuilder<T extends Record<string, any> = Record<string, any>> {
   submit(method: string, url: string, options?: any): Promise<any>;
   load(url: string): Promise<any>;
 
-  submitting(): this;
-  submitted(): this;
-  submitFailed(): this;
-  loading(): this;
-  loaded(): this;
-  loadFailed(): this;
+  setSubmitting(): this;
+  setSubmitted(): this;
+  setSubmitFailed(): this;
+  setLoading(): this;
+  setLoaded(): this;
+  setLoadFailed(): this;
 
   transform(callback: (data: T) => any): this;
 


### PR DESCRIPTION
## Summary
- unify FormBuilder state into a single reactive object
- expose `successful`, `failed`, `loading`, `loaded`, `wasLoading`, and `wasSubmitting` helpers
- rename internal state mutation methods (setSubmitting, setSubmitted, etc.)
- adjust WyxosForm component and specs to use new state API
- update TypeScript definitions

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6841d68a7548832c9a0dd24315ac659c