### PR TITLE
Fix unhandled rejection in Listing spec

### DIFF
--- a/tests/utilities/Listing.spec.js
+++ b/tests/utilities/Listing.spec.js
@@ -126,7 +126,10 @@ describe('Listing', () => {
   it('tracks state correctly during failed search operation', async () => {
     axios.get.mockRejectedValue(new Error('Network error'))
     const listing = Listing.create({ page: 1 })
-    listing.load('/items')
+    // load() sets internal URL and returns a promise. Since the axios call is
+    // mocked to reject, we must catch the promise to avoid an unhandled
+    // rejection during the test.
+    listing.load('/items').catch(() => {})
 
     // Start search
     const searchPromise = listing.search().catch(() => {})


### PR DESCRIPTION
## Summary
- catch rejected `load()` call in Listing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843f570a188832cbc7c9b799da42f9e