### PR TITLE
Add additional unit tests

### DIFF
--- a/tests/utilities/Filter.spec.js
+++ b/tests/utilities/Filter.spec.js
@@ -67,4 +67,12 @@ describe('Filter', () => {
     filter.query.search = 'changed'
     expect(filter.isDefault('search')).toBe(false)
   })
+
+  it('should return filled fields', () => {
+    filter.query.empty = ''
+    filter.query.extra = null
+    filter.query.valid = 'value'
+    const filled = filter.getFilledFields()
+    expect(filled).toEqual({ page: 1, search: 'test', valid: 'value' })
+  })
 })

--- a/tests/utilities/FormErrors.spec.js
+++ b/tests/utilities/FormErrors.spec.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import FormErrors from '../../src/utilities/FormErrors'
+
+describe('FormErrors', () => {
+  it('creates instance and manages bags', () => {
+    const errors = FormErrors.create()
+    errors.createBag('custom')
+    expect(errors.all('custom')).toEqual([])
+  })
+
+  it('sets errors from response and retrieves them', () => {
+    const errors = FormErrors.create()
+    const responseError = {
+      response: {
+        data: {
+          errors: {
+            name: ['required'],
+            email: ['invalid']
+          }
+        }
+      }
+    }
+
+    errors.set(responseError)
+
+    expect(errors.has('name')).toBe(true)
+    expect(errors.get('name')).toEqual({ message: 'required', variant: 'danger' })
+    expect(errors.all()).toEqual([
+      { key: 'name', message: 'required' },
+      { key: 'email', message: 'invalid' }
+    ])
+  })
+
+  it('throws when setting with non validation error', () => {
+    const errors = FormErrors.create()
+    expect(() => errors.set({})).toThrow()
+  })
+
+  it('updates and clears errors', () => {
+    const errors = FormErrors.create()
+    errors.setOne('field', 'invalid')
+    expect(errors.get('field')).toEqual({ message: 'invalid', variant: 'danger' })
+
+    errors.setOne('field', 'changed')
+    expect(errors.get('field')).toEqual({ message: 'changed', variant: 'danger' })
+
+    errors.clear('field')
+    expect(errors.has('field')).toBe(false)
+
+    errors.setOne('field', 'again')
+    errors.clear()
+    expect(errors.all()).toEqual([])
+  })
+})

--- a/tests/utilities/Listing.spec.js
+++ b/tests/utilities/Listing.spec.js
@@ -98,6 +98,18 @@ describe('Listing', () => {
     expect(lastCall[1].params).toEqual({ page: 1, name: 'JOHN' })
   })
 
+  it('filters out empty query parameters by default', async () => {
+    axios.get.mockResolvedValue({ data: { listing: {} } })
+    const listing = Listing.create({ page: 1, name: '', category: 'books', extra: null })
+    listing.load('/items')
+
+    await listing.search()
+
+    const lastCall = axios.get.mock.calls[axios.get.mock.calls.length - 1]
+    expect(lastCall[0]).toBe('/items')
+    expect(lastCall[1].params).toEqual({ page: 1, category: 'books' })
+  })
+
   it('tracks state correctly during search operation', async () => {
     axios.get.mockResolvedValue({ data: { listing: {} } })
     const listing = Listing.create({ page: 1 })


### PR DESCRIPTION
## Summary
- test form error handling utilities
- cover Filter.getFilledFields
- verify Listing.search filters empty params

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843f7b7d5c8832c93d82205175b6288